### PR TITLE
fix: use the correct repo for saving changes

### DIFF
--- a/github_importer.rb
+++ b/github_importer.rb
@@ -32,7 +32,7 @@ BLACKLISTED_REPOS = [].freeze
 
 GH_ACCESS_TOKEN = ENV.fetch('GH_ACCESS_TOKEN', '')
 
-SAVE_TO_REPO = "bfabio/developers.italia.it-data"
+SAVE_TO_REPO = "italia/developers.italia.it-data"
 
 def fetch(url, headers = {})
   rest_params = {


### PR DESCRIPTION
The bfabio repo is a redirect, but let use the correct one regardless.